### PR TITLE
feat: Enable ESO to orchestrate NooBaa certs and ensure RHOAI install cleanly

### DIFF
--- a/charts/all/rhoai/templates/customizedkueuedeployment.yaml
+++ b/charts/all/rhoai/templates/customizedkueuedeployment.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   annotations:
+      argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
       argocd.argoproj.io/sync-wave: "10"
   generation: 1
   labels:

--- a/charts/all/rhoai/templates/defaultkueueflavor.yaml
+++ b/charts/all/rhoai/templates/defaultkueueflavor.yaml
@@ -3,4 +3,5 @@ kind: ResourceFlavor
 metadata:
   name: default-flavor
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "10"

--- a/charts/all/rhoai/templates/kueuelocalqueue.yaml
+++ b/charts/all/rhoai/templates/kueuelocalqueue.yaml
@@ -4,6 +4,7 @@ metadata:
   namespace: test-project
   name: local-queue-test
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     kueue.x-k8s.io/default-queue: 'true'
     argocd.argoproj.io/sync-wave: "10"
 spec:

--- a/charts/all/rhoai/templates/spot-resource-flavour.yaml
+++ b/charts/all/rhoai/templates/spot-resource-flavour.yaml
@@ -2,6 +2,9 @@ apiVersion: kueue.x-k8s.io/v1beta1
 kind: ResourceFlavor
 metadata:
   name: "gpu"
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "10"
 spec:
   nodeLabels:
     instance-type: gpu

--- a/charts/all/rhoai/templates/team-a-kueueclusterqueue.yaml
+++ b/charts/all/rhoai/templates/team-a-kueueclusterqueue.yaml
@@ -4,6 +4,7 @@ metadata:
   name: "cluster-queue-a"
   
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "10"
 spec:
   namespaceSelector: {}  # match all.

--- a/charts/all/rhoai/templates/team-b-kueueclusterqueue.yaml
+++ b/charts/all/rhoai/templates/team-b-kueueclusterqueue.yaml
@@ -3,6 +3,7 @@ kind: ClusterQueue
 metadata:
   name: "cluster-queue-b"
   annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
     argocd.argoproj.io/sync-wave: "10"
 spec:
   namespaceSelector: {}  # match all.

--- a/charts/all/test-dsp-a/templates/data-connection.yaml
+++ b/charts/all/test-dsp-a/templates/data-connection.yaml
@@ -32,11 +32,11 @@ spec:
   data:
     - secretKey: AWS_ACCESS_KEY_ID
       remoteRef:
-        key: "{{ .Values.dsp.dataConnectionESOKey }}{{ .Values.dsp.name }}-aws"
+        key: "{{ .Values.dsp.dataConnectionESOKey }}"
         property: AWS_ACCESS_KEY_ID
     - secretKey: AWS_SECRET_ACCESS_KEY
       remoteRef:
-        key: "{{ .Values.dsp.dataConnectionESOKey }}{{ .Values.dsp.name }}-aws"
+        key: "{{ .Values.dsp.dataConnectionESOKey }}"
         property: AWS_SECRET_ACCESS_KEY
 #   AWS_ACCESS_KEY_ID: b0VQQ2lpamo2NnpwYnVNUUR0ZU0=
 #   AWS_DEFAULT_REGION: ""

--- a/charts/all/test-dsp-a/templates/push-secret.yaml
+++ b/charts/all/test-dsp-a/templates/push-secret.yaml
@@ -23,7 +23,7 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "/secret/data/global/bananas"
+          remoteKey: "/global/bananas"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 ---
 apiVersion: external-secrets.io/v1alpha1
@@ -50,6 +50,6 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "secret/data/global/apples"
+          remoteKey: "global/apples"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 {{ end }}

--- a/charts/all/test-dsp-a/templates/push-secret.yaml
+++ b/charts/all/test-dsp-a/templates/push-secret.yaml
@@ -23,7 +23,7 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "/global/bananas"
+          remoteKey: "data/global/bananas"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 ---
 apiVersion: external-secrets.io/v1alpha1
@@ -50,6 +50,6 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "global/apples"
+          remoteKey: "/data/global/apples"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 {{ end }}

--- a/charts/all/test-dsp-a/templates/push-secret.yaml
+++ b/charts/all/test-dsp-a/templates/push-secret.yaml
@@ -23,6 +23,6 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "global/{{ .Values.dsp.name }}-aws-secret-access-key"
+          remoteKey: "/secret/data/global/bananas"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 {{ end }}

--- a/charts/all/test-dsp-a/templates/push-secret.yaml
+++ b/charts/all/test-dsp-a/templates/push-secret.yaml
@@ -29,7 +29,7 @@ spec:
 apiVersion: external-secrets.io/v1alpha1
 kind: PushSecret
 metadata:
-  name: pushsecret # Customisable
+  name: pushsecret-apples # Customisable
   namespace: {{ .Values.dsp.name }} # Same of the SecretStores
 spec:
   updatePolicy: Replace # Policy to overwrite existing secrets in the provider on sync

--- a/charts/all/test-dsp-a/templates/push-secret.yaml
+++ b/charts/all/test-dsp-a/templates/push-secret.yaml
@@ -23,6 +23,33 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "/global/bananas"
+          remoteKey: "/secret/data/global/bananas"
+          property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: PushSecret
+metadata:
+  name: pushsecret # Customisable
+  namespace: {{ .Values.dsp.name }} # Same of the SecretStores
+spec:
+  updatePolicy: Replace # Policy to overwrite existing secrets in the provider on sync
+  deletionPolicy: Delete # the provider' secret will be deleted if the PushSecret is deleted
+  refreshInterval: 10s # Refresh interval for which push secret will reconcile
+  secretStoreRefs: # A list of secret stores to push secrets to
+    - name: {{ .Values.secretStore.name }}
+      kind: {{ .Values.secretStore.kind }}
+  selector:
+    secret:
+      name: {{ .Values.dsp.name }}-obc # Source Kubernetes secret to be pushed
+  data:
+    # - match:
+    #     secretKey: AWS_ACCESS_KEY_ID # Source Kubernetes secret key to be pushed
+    #     remoteRef:
+    #       remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-access-key" # Remote reference (where the secret is going to be pushed)
+    - match:
+        secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
+        remoteRef:
+          #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
+          remoteKey: "secret/data/global/apples"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 {{ end }}

--- a/charts/all/test-dsp-a/templates/push-secret.yaml
+++ b/charts/all/test-dsp-a/templates/push-secret.yaml
@@ -23,7 +23,7 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "data/global/bananas"
+          remoteKey: "global/bananas"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 ---
 apiVersion: external-secrets.io/v1alpha1
@@ -50,6 +50,6 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "/data/global/apples"
+          remoteKey: "/global/apples"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 {{ end }}

--- a/charts/all/test-dsp-a/templates/push-secret.yaml
+++ b/charts/all/test-dsp-a/templates/push-secret.yaml
@@ -23,6 +23,6 @@ spec:
         secretKey: AWS_SECRET_ACCESS_KEY # Source Kubernetes secret key to be pushed
         remoteRef:
           #remoteKey: "secret/data/global/{{ .Values.dsp.name }}-aws-secret-access-key"
-          remoteKey: "/secret/data/global/bananas"
+          remoteKey: "/global/bananas"
           property:  AWS_SECRET_ACCESS_KEY # Remote reference (where the secret is going to be pushed
 {{ end }}

--- a/charts/all/test-dsp-a/values.yaml
+++ b/charts/all/test-dsp-a/values.yaml
@@ -11,7 +11,7 @@ dsp:
   name: test-project-a
   description: "My dsp test project"
   notebookStorage: '20Gi'
-  pushSecret: false
+  pushSecret: true
   dataConnectionESOKey: 'secret/data/global/test-project-aws'
 
 

--- a/charts/all/test-dsp-a/values.yaml
+++ b/charts/all/test-dsp-a/values.yaml
@@ -12,7 +12,7 @@ dsp:
   description: "My dsp test project"
   notebookStorage: '20Gi'
   pushSecret: true
-  dataConnectionESOKey: 'secret/data/global/test-project-aws'
+  dataConnectionESOKey: 'secret/data/global/test-project-a-aws'
 
 
 # https://github.com/openshift-ai-examples/openshift-ai-examples/blob/main/openshift-ai-deploy-llm/manifests/3-notebook-template.yaml

--- a/common/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
+++ b/common/ansible/roles/vault_utils/tasks/vault_secrets_init.yaml
@@ -1,4 +1,3 @@
----
 - name: Is secrets backend already enabled
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
@@ -51,10 +50,7 @@
   kubernetes.core.k8s_exec:
     namespace: "{{ vault_ns }}"
     pod: "{{ vault_pod }}"
-    command: bash -e -c "vault write auth/{{ vault_hub }}/config token_reviewer_jwt={{ sa_token }}
-        kubernetes_host={{ vault_hub_kubernetes_host }}
-        kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-        issuer=https://kubernetes.default.svc"
+    command: bash -e -c "vault write auth/{{ vault_hub }}/config token_reviewer_jwt={{ sa_token }} kubernetes_host={{ vault_hub_kubernetes_host }} kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt issuer=https://kubernetes.default.svc"
 
 # This creates a {{ vault_global_policy }} policy that is applied to both hubs and spokes
 - name: Configure VP global policy template
@@ -64,6 +60,14 @@
     command: >
       bash -e -c "echo \"path \\\"secret/data/{{ vault_global_policy }}/*\\\" {
         capabilities = {{ vault_global_capabilities }} }\" > /tmp/policy-{{ vault_global_policy }}.hcl"
+
+- name: Configure VP global policy metadata template
+  kubernetes.core.k8s_exec:
+    namespace: "{{ vault_ns }}"
+    pod: "{{ vault_pod }}"
+    command: >
+      bash -e -c "echo \"path \\\"secret/metadata/{{ vault_global_policy }}/*\\\" {
+        capabilities = {{ vault_global_capabilities }} }\" >> /tmp/policy-{{ vault_global_policy }}.hcl"
 
 - name: Configure VP global policy
   kubernetes.core.k8s_exec:

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -12,6 +12,7 @@ clusterGroup:
   - nvidia-gpu-operator
   - openshift-serverless
   - redis
+  - test-project
   #- rhdh-operator 
   subscriptions:
     acm:


### PR DESCRIPTION
This sets up two things:

1. The RHOAI install had issues due to deploying a CRD in the same chart it was consumed this has been fixed.

2. Worked to ensure Noobaa secrets can be pushed into vault.

Thanks to @beekhof and @mbaldessari